### PR TITLE
chore: JDBC 설정

### DIFF
--- a/api-server/src/main/resources/application.properties
+++ b/api-server/src/main/resources/application.properties
@@ -3,4 +3,4 @@ spring.application.name=practice-space
 spring.datasource.url=${KUBE_DB_URL}
 spring.datasource.username=${KUBE_DB_USERNAME}
 spring.datasource.password=${KUBE_DB_PASSWORD}
-spring.datasource.driver-class-name=${KUBE_DB_DRIVER_CLASS_NAME}
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver

--- a/api-server/src/main/resources/application.properties
+++ b/api-server/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=practice-space
+
+spring.datasource.url=${KUBE_DB_URL}
+spring.datasource.username=${KUBE_DB_USERNAME}
+spring.datasource.password=${KUBE_DB_PASSWORD}
+spring.datasource.driver-class-name=${KUBE_DB_DRIVER_CLASS_NAME}


### PR DESCRIPTION
application.properties 파일에 JDBC 사용을 위한 DB url, username, password, driver class name을 명시했습니다.
서로 다른 개발환경 호환성, 배포 시 배포용 DB 사용을 위해 각각 url, username, password, driver class name을 시스템 환경변수에서 가져오는 걸로 했습니다.

시스템 환경변수에 다음 항목들을 추가해 주세요

KUBE_DB_URL: 사용할 데이터베이스 URL
KUBE_DB_USERNAME: 데이터베이스 아이디
KUBE_DB_PASSWORD: 데이터베이스 패스워드
KUBE_DB_DRIVER_CLASS_NAME: 드라이버 클래스

ex)
KUBE_DB_URL=jdbc:mysql://localhost:3306/test-db
KUBE_DB_USERNAME=scott
KUBE_DB_PASSWORD=tiger
KUBE_DB_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver

위 사항을 시스템 환경변수에 등록해 주세요